### PR TITLE
Feature `negate_unsigned` has been removed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![feature(test)]
-#![feature(negate_unsigned)]
 
 extern crate test;
 
 pub mod compact;
 pub mod readhex;
-
-


### PR DESCRIPTION
We didn't seem to be using it anyway.

(This makes it work on current nightly.)
