### PR TITLE
Move benchmarks to separate folder

### DIFF
--- a/benches/compact.rs
+++ b/benches/compact.rs
@@ -1,9 +1,9 @@
 #![feature(test)]
 
-extern crate indolenjson;
+extern crate indolentjson;
 extern crate test;
 
-use indolenjson::compact::*;
+use indolentjson::compact::*;
 use test::{black_box, Bencher};
 
 #[bench]

--- a/benches/compact.rs
+++ b/benches/compact.rs
@@ -1,0 +1,26 @@
+#![feature(test)]
+
+extern crate indolenjson;
+extern crate test;
+
+use indolenjson::compact::*;
+use test::{black_box, Bencher};
+
+#[bench]
+fn benchmark_compact(b : &mut Bencher) {
+    let test_string = black_box(r#"{
+        "A longish bit of JSON": true,
+        "containing": {
+            "whitespace": " ",
+            "unicode escapes ": "\uFFFF\u0FFF\u007F\uDBFF\uDFFF",
+            "other sorts of esacpes": "\b\t\n\f\r\"\\\/",
+            "unicode escapes for the other sorts of escapes":
+                "\u0008\u0009\u000A\u000C\u000D\u005C\u0022",
+            "numbers": [0, 1, 1e4, 1.0, -1.0e7 ],
+            "and more": [ true, false, null ]
+        }
+    }"#.as_bytes());
+    let mut output : Vec<u8> = Vec::with_capacity(test_string.len());
+    b.bytes = test_string.len() as u64;
+    b.iter(|| { output.clear(); compact_vector(test_string, &mut output) });
+}

--- a/benches/readhex.rs
+++ b/benches/readhex.rs
@@ -1,0 +1,14 @@
+#![feature(test)]
+
+extern crate indolenjson;
+extern crate test;
+
+use indolenjson::readhex::*;
+use test::{black_box, Bencher};
+
+#[bench]
+fn read_hexdigit(b: &mut Bencher) {
+    let x = black_box(b"0123");
+    b.bytes = x.len() as u64;
+    b.iter(|| { read_hexdigits(x[0], x[1], x[2], x[3]) });
+}

--- a/benches/readhex.rs
+++ b/benches/readhex.rs
@@ -1,9 +1,9 @@
 #![feature(test)]
 
-extern crate indolenjson;
+extern crate indolentjson;
 extern crate test;
 
-use indolenjson::readhex::*;
+use indolentjson::readhex::*;
 use test::{black_box, Bencher};
 
 #[bench]

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -141,8 +141,6 @@ pub fn compact(input_json: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test::black_box;
-    use test::Bencher;
 
     #[test]
     fn compact_json_object() {
@@ -189,24 +187,5 @@ mod tests {
         assert_eq!("[\"\u{FFFF}\"]", compact("[\"\\uFFFF\"]"));
         assert_eq!("[\"\u{20820}\"]", compact("[\"\\uD842\\uDC20\"]"));
         assert_eq!("[\"\u{10FFFF}\"]", compact("[\"\\uDBFF\\uDFFF\"]"));
-    }
-
-    #[bench]
-    fn benchmark_compact(b : &mut Bencher) {
-        let test_string = black_box(r#"{
-            "A longish bit of JSON": true,
-            "containing": {
-                "whitespace": " ",
-                "unicode escapes ": "\uFFFF\u0FFF\u007F\uDBFF\uDFFF",
-                "other sorts of esacpes": "\b\t\n\f\r\"\\\/",
-                "unicode escapes for the other sorts of escapes":
-                    "\u0008\u0009\u000A\u000C\u000D\u005C\u0022",
-                "numbers": [0, 1, 1e4, 1.0, -1.0e7 ],
-                "and more": [ true, false, null ]
-            }
-        }"#.as_bytes());
-        let mut output : Vec<u8> = Vec::with_capacity(test_string.len());
-        b.bytes = test_string.len() as u64;
-        b.iter(|| { output.clear(); compact_vector(test_string, &mut output) });
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,2 @@
-#![feature(test)]
-
-extern crate test;
-
 pub mod compact;
 pub mod readhex;

--- a/src/readhex.rs
+++ b/src/readhex.rs
@@ -23,8 +23,6 @@ pub fn read_hexdigits(h0: u8, h1: u8, h2: u8, h3: u8) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test::Bencher;
-    use test::black_box;
 
     pub fn read_hexdigit_4(input: &[u8], pos: usize) -> u32 {
         return read_hexdigits(
@@ -34,24 +32,17 @@ mod tests {
 
     #[test]
     fn readhex_uppercase() {
-        assert_eq!(0x0123, read_hexdigit_4("0123".as_bytes(), 0));
-        assert_eq!(0x4567, read_hexdigit_4("4567".as_bytes(), 0));
-        assert_eq!(0x89AB, read_hexdigit_4("89AB".as_bytes(), 0));
-        assert_eq!(0xCDEF, read_hexdigit_4("CDEF".as_bytes(), 0));
+        assert_eq!(0x0123, read_hexdigit_4(b"0123", 0));
+        assert_eq!(0x4567, read_hexdigit_4(b"4567", 0));
+        assert_eq!(0x89AB, read_hexdigit_4(b"89AB", 0));
+        assert_eq!(0xCDEF, read_hexdigit_4(b"CDEF", 0));
     }
 
     #[test]
     fn readhex_lowercase() {
-        assert_eq!(0x0123, read_hexdigit_4("0123".as_bytes(), 0));
-        assert_eq!(0x4567, read_hexdigit_4("4567".as_bytes(), 0));
-        assert_eq!(0x89AB, read_hexdigit_4("89ab".as_bytes(), 0));
-        assert_eq!(0xCDEF, read_hexdigit_4("cdef".as_bytes(), 0));
-    }
-
-    #[bench]
-    fn read_hexdigit(b: &mut Bencher) {
-        let x = black_box("0123".as_bytes());
-        b.bytes = x.len() as u64;
-        b.iter(|| { read_hexdigit_4(x, 0) });
+        assert_eq!(0x0123, read_hexdigit_4(b"0123", 0));
+        assert_eq!(0x4567, read_hexdigit_4(b"4567", 0));
+        assert_eq!(0x89AB, read_hexdigit_4(b"89ab", 0));
+        assert_eq!(0xCDEF, read_hexdigit_4(b"cdef", 0));
     }
 }


### PR DESCRIPTION
Depends on #1, #4 

This allows the library to be built on stable.
