### PR TITLE
Make string escaping return Cow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "indolentjson"
 version = "0.1.0"
 authors = ["Mark Haines <mjark@negativecurvature.net>"]
 
-[dev-dependencies]
-quickcheck = "0.2"
-quickcheck_macros = "0.2"
+[dependencies]
+quickcheck = {version = "0.2", optional = true}
+quickcheck_macros = {version = "0.2", optional = true}
+
+[features]
+quickcheck_test = ["quickcheck", "quickcheck_macros"]  # Enables testing with quickcheck

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,6 @@ name = "indolentjson"
 version = "0.1.0"
 authors = ["Mark Haines <mjark@negativecurvature.net>"]
 
-[dependencies]
+[dev-dependencies]
+quickcheck = "0.2"
+quickcheck_macros = "0.2"

--- a/benches/strings.rs
+++ b/benches/strings.rs
@@ -1,0 +1,36 @@
+#![feature(test)]
+
+extern crate indolentjson;
+extern crate test;
+
+use indolentjson::strings::*;
+use test::Bencher;
+
+
+#[bench]
+fn noop_escape(b: &mut Bencher) {
+    b.iter(|| {
+        escape_bytes(b"test")
+    });
+}
+
+#[bench]
+fn escape_controls(b: &mut Bencher) {
+    b.iter(|| {
+        escape_bytes(b"\t\n\r\\")
+    });
+}
+
+#[bench]
+fn noop_unescape(b: &mut Bencher) {
+    b.iter(|| {
+        unescape_bytes(b"test")
+    });
+}
+
+#[bench]
+fn unescape_controls(b: &mut Bencher) {
+    b.iter(|| {
+        unescape_bytes(br#"\t\n\r\\"#)
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#![cfg_attr(test, feature(plugin))]
-#![cfg_attr(test, plugin(quickcheck_macros))]
+#![cfg_attr(all(test, feature = "quickcheck_test"), feature(plugin))]
+#![cfg_attr(all(test, feature = "quickcheck_test"), plugin(quickcheck_macros))]
 
 pub mod compact;
 pub mod readhex;
@@ -22,5 +22,5 @@ pub mod parse;
 pub mod validate;
 pub mod strings;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "quickcheck_test"))]
 extern crate quickcheck;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#![cfg_attr(test, feature(plugin))]
+#![cfg_attr(test, plugin(quickcheck_macros))]
+
 pub mod compact;
 pub mod readhex;
 pub mod parse;
 pub mod validate;
 pub mod strings;
+
+#[cfg(test)]
+extern crate quickcheck;

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,23 +1,28 @@
-pub fn unescape_bytes(input: &[u8]) -> Vec<u8> {
-    let mut output = Vec::new();
-    let mut iter = input.iter();
+use std::borrow::Cow;
+
+
+pub fn unescape_bytes<'a>(input: &'a [u8]) -> Cow<'a, [u8]> {
+    let mut output = Cow::Borrowed(input);
+    let mut iter = input.iter().enumerate();
     loop {
-        let c = match iter.next() {
-            None => return output,
-            Some(value) => *value,
+        let (idx, c) = match iter.next() {
+            None => break,
+            Some((idx, value)) => (idx, *value),
         };
         if c == b'\\' {
+            let vec = into_buf(idx, &mut output);
+
             let escaped = match iter.next() {
                 None => panic!("Invalid escape"),
-                Some(value) => *value,
+                Some((_, value)) => *value,
             };
             match escaped {
-                b'"' | b'\\' => output.push(escaped),
-                b'b' => output.push(0x08),
-                b'f' => output.push(0x0C),
-                b'n' => output.push(0x0A),
-                b'r' => output.push(0x0D),
-                b't' => output.push(0x09),
+                b'"' | b'\\' => vec.push(escaped),
+                b'b' => vec.push(0x08),
+                b'f' => vec.push(0x0C),
+                b'n' => vec.push(0x0A),
+                b'r' => vec.push(0x0D),
+                b't' => vec.push(0x09),
                 b'u' => {
                     // Skip the first two digits since they are zero.
                     if iter.next() == None || iter.next() == None {
@@ -25,57 +30,67 @@ pub fn unescape_bytes(input: &[u8]) -> Vec<u8> {
                     }
                     let h2 = match iter.next() {
                         None => panic!("Invalid escape"),
-                        Some(value) => *value,
+                        Some((_, value)) => *value,
                     };
                     let h3 = match iter.next() {
                         None => panic!("Invalid escape"),
-                        Some(value) => *value,
+                        Some((_, value)) => *value,
                     };
                     let value = ((h2 - b'0') << 4) + ((h3 - b'0') & 0x1F);
                     if h3 > b'9' {
-                        output.push(value - 7);
+                        vec.push(value - 7);
                     } else {
-                        output.push(value);
+                        vec.push(value);
                     }
                 },
-                _ => return output,
+                _ => panic!("Invalid escape"),
             }
-        } else {
-            output.push(c);
         }
     }
+
+    output
 }
 
 const HEX : [u8 ; 16] = *b"0123456789ABCDEF";
 
-pub fn escape_bytes(input: &[u8]) -> Vec<u8> {
-    let mut output = Vec::new();
-    for c in input.iter() {
+pub fn escape_bytes<'a>(input: &'a [u8]) -> Cow<'a, [u8]> {
+    let mut output = Cow::Borrowed(input);
+    for (i, c) in input.iter().enumerate() {
         if *c < b' ' {
-            output.push(b'\\');
+            let vec = into_buf(i, &mut output);
+            vec.push(b'\\');
             match *c {
-                0x08 => output.push(b'b'),
-                0x09 => output.push(b't'),
-                0x0A => output.push(b'n'),
-                0x0C => output.push(b'f'),
-                0x0D => output.push(b'r'),
+                0x08 => vec.push(b'b'),
+                0x09 => vec.push(b't'),
+                0x0A => vec.push(b'n'),
+                0x0C => vec.push(b'f'),
+                0x0D => vec.push(b'r'),
                 _ => {
-                    output.push(b'u');
-                    output.push(b'0');
-                    output.push(b'0');
-                    output.push(b'0' + (c >> 4));
-                    output.push(HEX[(c & 0xF) as usize]);
+                    vec.extend(b"u00");
+                    vec.push(b'0' + (c >> 4));
+                    vec.push(HEX[(c & 0xF) as usize]);
                 }
             }
             continue
         }
         if *c == b'\"' || *c == b'\\' {
-            output.push(b'\\');
+            let vec = into_buf(i, &mut output);
+            vec.push(b'\\');
+            vec.push(*c);
         }
-        output.push(*c);
     }
     output
 }
+
+fn into_buf<'a, 'b>(idx: usize, cow: &'b mut Cow<'a, [u8]>) -> &'b mut Vec<u8> {
+    if let Cow::Borrowed(input) = *cow {
+        let mut vec = Vec::with_capacity(input.len() * 2);
+        vec.extend(&input[..idx]);
+        *cow = Cow::Owned(vec);
+    }
+    cow.to_mut()
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -84,70 +99,70 @@ mod tests {
     #[test]
     fn escape_control_characters() {
         assert_eq!(
-            r#"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007"#,
-            String::from_utf8(escape_bytes(
+            &br#"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007"#[..],
+            &escape_bytes(
                 b"\x00\x01\x02\x03\x04\x05\x06\x07"
-            )).unwrap()
+            )[..]
         );
         assert_eq!(
-            r#"\b\t\n\u000B\f\r\u000E\u000F"#,
-            String::from_utf8(escape_bytes(
+            &br#"\b\t\n\u000B\f\r\u000E\u000F"#[..],
+            &escape_bytes(
                 b"\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
-            )).unwrap()
+            )[..]
         );
         assert_eq!(
-            r#"\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017"#,
-            String::from_utf8(escape_bytes(
+            &br#"\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017"#[..],
+            &escape_bytes(
                 b"\x10\x11\x12\x13\x14\x15\x16\x17"
-            )).unwrap()
+            )[..]
         );
         assert_eq!(
-            r#"\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F"#,
-            String::from_utf8(escape_bytes(
+            &br#"\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F"#[..],
+            &escape_bytes(
                 b"\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F"
-            )).unwrap()
+            )[..]
         );
     }
 
     #[test]
     fn unescape_control_characters() {
         assert_eq!(
-            "\x00\x01\x02\x03\x04\x05\x06\x07",
-            String::from_utf8(unescape_bytes(
+            &b"\x00\x01\x02\x03\x04\x05\x06\x07"[..],
+            &unescape_bytes(
                 br#"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007"#,
-            )).unwrap()
+            )[..]
         );
         assert_eq!(
-            "\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F",
-            String::from_utf8(unescape_bytes(
+            &b"\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"[..],
+            &unescape_bytes(
                 br#"\b\t\n\u000B\f\r\u000E\u000F"#,
-            )).unwrap()
+            )[..]
         );
         assert_eq!(
-            "\x10\x11\x12\x13\x14\x15\x16\x17",
-            String::from_utf8(unescape_bytes(
+            &b"\x10\x11\x12\x13\x14\x15\x16\x17"[..],
+            &unescape_bytes(
                 br#"\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017"#,
-            )).unwrap()
+            )[..]
         );
         assert_eq!(
-            "\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F",
-            String::from_utf8(unescape_bytes(
+            &b"\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F"[..],
+            &unescape_bytes(
                 br#"\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F"#,
-            )).unwrap()
+            )[..]
         );
     }
 
     #[test]
     fn escape_slash_and_quote() {
         assert_eq!(
-            r#"\"\\"#, String::from_utf8(escape_bytes(b"\"\\")).unwrap()
+            br#"\"\\"#, &escape_bytes(b"\"\\")[..]
         );
     }
 
     #[test]
     fn unescape_slash_and_quote() {
         assert_eq!(
-            "\"\\", String::from_utf8(unescape_bytes(br#"\"\\"#)).unwrap()
+            b"\"\\", &unescape_bytes(br#"\"\\"#)[..]
         );
     }
 }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -93,8 +93,8 @@ pub fn escape_bytes<'a>(input: &'a [u8]) -> Cow<'a, [u8]> {
 }
 
 
-#[cfg(test)]
-mod tests {
+#[cfg(all(feature = "quickcheck_test", test))]
+mod quickcheck_test {
     use super::*;
     use quickcheck::TestResult;
 
@@ -114,6 +114,11 @@ mod tests {
         }
         return TestResult::discard()
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
 
     #[test]
     fn escape_control_characters() {


### PR DESCRIPTION
Also:
- Adds some benchmarks
- Makes `unescape_bytes` return an option rather than panic
- Adds a couple of basic quickcheck tests for escaping.

I'm perfectly happy to remove the quickcheck stuff if you want, but it seems to run fairly instantly and it picked up some bugs for me.
